### PR TITLE
Search command

### DIFF
--- a/app/Events/PhoneNumberQueried.php
+++ b/app/Events/PhoneNumberQueried.php
@@ -24,14 +24,22 @@ class PhoneNumberQueried extends Event
                 ->trim()
                 ->explode(' ')
                 ->filter(fn ($token) => (new BasePhoneNumber($token, 'US'))->isValid())
-                ->first(),
+                ->first() ?? '',
         );
 
-        // TODO: We may need to account for SMS length limits here
         if ($check_in = $found->check_ins()->latest()->first()) {
+
+            $timestamp = "{$check_in->created_at->diffForHumans()}:";
+            $message = $check_in->body;
+            $overflow = strlen($timestamp) + strlen($message) - 160;
+
+            if($overflow > 0) {
+                $message = substr($message, 0, strlen($message) - $overflow - 3) . '...';
+            }
+
             return implode(' ', [
-                "From {$found->value} {$check_in->created_at->diffForHumans()}:",
-                $check_in->body,
+                $timestamp,
+                $message,
             ]);
         }
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -27,8 +27,9 @@ Artisan::command('sms', function () {
             update: $command->message,
             payload: $synthetic_payload,
         ),
-        SmsCommandType::Search => PhoneNumberQueried::commit(
-            phone_number: $phone_number,
+        SmsCommandType::Search => PhoneNumberQueried::webhook(
+            request: new \Illuminate\Http\Request(),
+            command: $command,
         ),
         SmsCommandType::OptOut => OptOutRequested::commit(
             phone_number: $phone_number,


### PR DESCRIPTION
### Overview

Saw a TODO for character limits so I took a crack at it.

If this is already handled, feel free to delete.

### Notes

- Shortened the opening line so more of the update could come through
- Added ellipses if the message overflows - **This takes away characters but I figured it requires less explanation so its probably better than nothing**
- Fixed a bug where invalid/empty phone number would crash the search command before it could get to the verbs validate function
