### PR TITLE
Fix tests and Enable CI test runs.

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -1,0 +1,55 @@
+name: Laravel
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  laravel-tests:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          tools: composer:v2
+
+      - uses: actions/checkout@v3
+
+      - name: Copy .env
+        run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache/files
+          key: dependencies-composer-${{ hashFiles('composer.json') }}
+
+      - name: Install Composer Dependencies
+        run: |
+          composer config "http-basic.nova.laravel.com" "${{ secrets.NOVA_USERNAME }}" "${{ secrets.NOVA_LICENSE_KEY }}"
+          composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+
+      - name: Generate key
+        run: php artisan key:generate
+
+      - name: Directory Permissions
+        run: chmod -R 777 storage bootstrap/cache
+
+      - name: Install Front End Assets
+        run: npm install
+
+      - name: Build Front End Assets
+        run: npm run build
+
+      - name: Execute tests (Unit and Feature tests) via PHPUnit
+        env:
+          DB_CONNECTION: sqlite_testing
+          KNACK_APPLICATION_ID: ${{ secrets.KNACK_APPLICATION_ID }}
+          KNACK_API_KEY: ${{ secrets.KNACK_API_KEY }}
+        run: ./vendor/bin/pest

--- a/tests/Feature/SearchTest.php
+++ b/tests/Feature/SearchTest.php
@@ -3,10 +3,11 @@
 use App\Models\PhoneNumber;
 use App\Models\Subscription;
 use App\Models\User;
+use Thunk\Verbs\Facades\Verbs;
 
 use function Pest\Laravel\post;
 
-it('you can search without providing an email', function () {
+it('you can search', function () {
     $response = post(route('search'), [
         'phone_number' => '+12024561111',
     ]);
@@ -16,21 +17,4 @@ it('you can search without providing an email', function () {
     expect(User::count())->toBe(0)
         ->and(Subscription::count())->toBe(0)
         ->and(PhoneNumber::findByValue('+12024561111'))->toBeInstanceOf(PhoneNumber::class);
-});
-
-it('you can search and include an email for notifications', function () {
-    $response = post(route('search'), [
-        'phone_number' => '+12024561111',
-        'email' => 'john@thunk.gov',
-    ]);
-
-    $response->assertRedirect(route('phone-number', '+12024561111'));
-
-    $user = User::where('email', 'john@thunk.gov')->sole();
-
-    $subscribed_phone_numbers = $user->subscriptions
-        ->map(fn (Subscription $subscription) => e164($subscription->phone_number));
-
-    expect($subscribed_phone_numbers)->toHaveCount(1)
-        ->first()->toBe('+12024561111');
 });

--- a/tests/Feature/SubscribeTest.php
+++ b/tests/Feature/SubscribeTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Models\Subscription;
+use App\Models\User;
+use Thunk\Verbs\Facades\Verbs;
+
+use function Pest\Laravel\post;
+
+it('you can search and include an email for notifications', function () {
+    $response = post(route('subscribe'), [
+        'phone_number' => '+12024561111',
+        'email' => 'john@thunk.gov',
+    ]);
+
+    $response->assertRedirect(route('phone-number', '+12024561111'));
+
+    Verbs::commit();
+
+    $user = User::where('email', 'john@thunk.gov')->sole();
+
+    $subscribed_phone_numbers = $user->subscriptions
+        ->map(fn (Subscription $subscription) => e164($subscription->phone_number));
+
+    expect($subscribed_phone_numbers)->toHaveCount(1)
+        ->first()->toBe('+12024561111');
+});


### PR DESCRIPTION
Fixes a test that seems to have been leftover from before the `search` -> `subscribe` transition.

Also enables test runs in CI to prevent regressions in the future.