### PR TITLE
Resolve hitting `/docs` throwing a parameter count exception

### DIFF
--- a/app/Http/Controllers/GoogleDocsController.php
+++ b/app/Http/Controllers/GoogleDocsController.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Cache;
 
 class GoogleDocsController extends Controller
 {
-    public function __invoke(?string $format)
+    public function __invoke(?string $format = 'html')
     {
         $doc = Cache::remember(
             "doc-$format",

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,7 +10,7 @@ use App\Http\Controllers\PhoneNumberController;
 
 Route::post('/search', SearchController::class)->name('search');
 Route::get('/stats', AnalyticsController::class);
-Route::get('/docs/{format?}', GoogleDocsController::class);
+Route::get('/docs/{format?}', GoogleDocsController::class)->name('docs');
  
 
 

--- a/tests/Feature/AidDocTest.php
+++ b/tests/Feature/AidDocTest.php
@@ -32,4 +32,4 @@ describe('aid documents', function () {
 
         $response->assertStatus(200);
     });
-});
+})->skip();

--- a/tests/Feature/AidDocTest.php
+++ b/tests/Feature/AidDocTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use function Pest\Laravel\get;
+
+describe('aid documents', function () {
+    it('shows the aid doc', function () {
+        $response = get(route('docs'));
+
+        $response->assertStatus(200);
+    });
+
+    it('shows the aid doc in html', function () {
+        $response = get(route('docs', ['format' => 'html']));
+
+        $response->assertStatus(200);
+    });
+
+    it('shows the aid doc in txt', function () {
+        $response = get(route('docs', ['format' => 'txt']));
+
+        $response->assertStatus(200);
+    });
+
+    it('shows the aid doc in rtf', function () {
+        $response = get(route('docs', ['format' => 'rtf']));
+
+        $response->assertStatus(200);
+    });
+
+    it('shows the aid doc in markdown', function () {
+        $response = get(route('docs', ['format' => 'md']));
+
+        $response->assertStatus(200);
+    });
+});


### PR DESCRIPTION
- This also includes really bare bones tests for the `/docs` routes; however, I have marked them to skip. This is so the pipeline doesn't have to hit the Google servers; it's not my token so I am deferring this to someone with more token-power ;)

Current live: https://disastercheckin.com/docs

Thanks!