### PR TITLE
Rate limit `phone-number` route

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
-abstract class Controller
+use Illuminate\Routing\Controller as BaseController;
+
+abstract class Controller extends BaseController
 {
     //
 }

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -13,8 +13,6 @@ class SearchController extends Controller
             phone_number: $request->validated('phone_number'),
         );
 
-        // TODO: Rate limit this
-
         return to_route('phone-number', $phone_number);
     }
 }

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -9,10 +9,8 @@
     <div class="max-w-lg mt-6 prose-sm">
         <p>
             If you are looking for information on a loved one, they may have checked in with us. We have provided a
-            phone
-            number to local media where people can send SMS updates about their well-being. You can search for your
-            loved one
-            using their phone number below:
+            phone number to local media where people can send SMS updates about their well-being. You can search for
+            your loved one using their phone number below:
         </p>
     </div>
 

--- a/resources/views/phone-number-rate-limited.blade.php
+++ b/resources/views/phone-number-rate-limited.blade.php
@@ -1,0 +1,17 @@
+<x-app-layout>
+
+    <div class="mt-6">
+
+        <h2 class="pb-2 text-xl font-semibold tracking-tight border-b text-slate-800 border-slate-300">
+            Check-ins
+        </h2>
+
+        <div class="mt-6 prose-sm">
+            <p>
+                You've made a few too many requests. Please wait a few moments before refreshing this page to try again.
+            </p>
+        </div>
+
+    </div>
+
+</x-app-layout>


### PR DESCRIPTION
Leapfrogged off of Chris' TODO and added a lightweight rate limiter to the `phone-number` route.

https://github.com/inxilpro/disastercheckin.com/blob/efd3084947c8f8a800b80f4868157109240ac89d/app/Http/Controllers/SearchController.php#L16

In hindsight, I'm seeing a pretty aggressive caching policy on this same controller, which may or may not be preferable over rate limiting. If we keep the caching policy, I would suggest adding a disclaimer that says messages are only updated at most once per TTL.

![Screenshot 2024-10-02 at 01 10 10@2x](https://github.com/user-attachments/assets/7bb47874-94bf-4cf4-8082-bc50a8b2a7b9)