### PR TITLE
Adds support for SMS line breaks

### DIFF
--- a/app/Data/SmsParser.php
+++ b/app/Data/SmsParser.php
@@ -28,7 +28,7 @@ class SmsParser
             ->map(fn ($prefix) => preg_quote($prefix, '/'))
             ->implode('|');
 
-        preg_match('/^\s*(?P<command>'.$prefixes.')?:?\s*(?P<message>.*)\s*$/i', $body, $matches);
+        preg_match('/^\s*(?P<command>'.$prefixes.')?\s*:?\s*(?P<message>.*?)\s*$/is', $body, $matches);
 
         return [
             strtolower($matches['command'] ?? ''),

--- a/app/Models/CheckIn.php
+++ b/app/Models/CheckIn.php
@@ -3,10 +3,12 @@
 namespace App\Models;
 
 use Glhd\Bits\Database\HasSnowflakes;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\HtmlString;
 
 class CheckIn extends Model
 {
@@ -16,6 +18,15 @@ class CheckIn extends Model
     protected static function booted()
     {
         static::saved(fn (CheckIn $c) => Cache::forget("phone-number-view:{$c->phone_number->value}"));
+    }
+
+    protected function htmlBody(): Attribute
+    {
+        return Attribute::make(
+            get: fn(mixed $value, array $attributes) => new HtmlString(
+                nl2br(e($attributes['body']), false)
+            )
+        );
     }
 
     public function phone_number(): BelongsTo

--- a/resources/views/phone-number.blade.php
+++ b/resources/views/phone-number.blade.php
@@ -26,7 +26,7 @@
 
             <div
                 class="px-4 py-2 mt-2 font-medium text-green-900 shadow-sm ring-1 ring-green-500 rounded-r-md rounded-bl-md bg-green-200/30">
-                {{ $latest_check_in->body }}
+                {{ $latest_check_in->html_body }}
             </div>
 
             <x-subscribe-form :phone_number="$phone_number"/>
@@ -54,7 +54,7 @@
                                 {{ $check_in->created_at->diffForHumans() }}
                             </td>
                             <td class="py-1 pl-2">
-                                {{ $check_in->body }}
+                                {{ $check_in->html_body }}
                             </td>
                         </tr>
                     @endforeach

--- a/routes/console.php
+++ b/routes/console.php
@@ -11,10 +11,11 @@ use Propaganistas\LaravelPhone\PhoneNumber;
 
 use function Laravel\Prompts\note;
 use function Laravel\Prompts\text;
+use function Laravel\Prompts\textarea;
 
 Artisan::command('sms', function () {
     $raw_phone = text('Phone number', default: '202-456-1111', required: true, validate: fn ($value) => (new PhoneNumber($value, 'US'))->isValid() ? null : 'Invalid phone number');
-    $raw_body = text('Message body', required: true, validate: fn ($value) => mb_strlen($value) <= 160 ? null : 'Message must be under 160 chars');
+    $raw_body = textarea('Message body', required: true, validate: fn ($value) => mb_strlen($value) <= 160 ? null : 'Message must be under 160 chars');
 
     $synthetic_payload = ['raw_phone' => $raw_phone, 'raw_body' => $raw_body, 'synthetic' => true];
 

--- a/tests/Unit/CheckInModelTest.php
+++ b/tests/Unit/CheckInModelTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Data\SmsCommand;
+use App\Data\SmsCommandType;
+use App\Data\SmsParser;
+use App\Models\CheckIn;
+
+test('escapes body HTML', function () {
+    $checkin = new CheckIn;
+    $checkin->body = "<script>alert()</script>";
+    expect((string)$checkin->html_body)->toBe("&lt;script&gt;alert()&lt;/script&gt;");
+});
+
+
+test('supports multiline body', function () {
+    $checkin = new CheckIn;
+    $checkin->body = "foo\n<bar>\nbaz";
+    expect((string)$checkin->html_body)->toBe("foo<br>\n&lt;bar&gt;<br>\nbaz");
+});

--- a/tests/Unit/SmsParserTest.php
+++ b/tests/Unit/SmsParserTest.php
@@ -27,6 +27,14 @@ test('Update command is parsed', function () {
     $parsed = SmsParser::parse("UPDATEi'm doing alright");
     expect($parsed->command)->toBe(SmsCommandType::Update)
         ->and($parsed->message)->toBe("i'm doing alright");
+
+    $parsed = SmsParser::parse("\n\n\nUPDATE \n : \n I'm doing alright \n");
+    expect($parsed->command)->toBe(SmsCommandType::Update)
+        ->and($parsed->message)->toBe("I'm doing alright");
+
+    $parsed = SmsParser::parse("\n\n\nUPDATE \n : \n I'm\ndoing\nalright \n");
+    expect($parsed->command)->toBe(SmsCommandType::Update)
+        ->and($parsed->message)->toBe("I'm\ndoing\nalright");
 })->group('parser');
 
 test('Help command is parsed', function () {

--- a/tests/Unit/SmsParserTest.php
+++ b/tests/Unit/SmsParserTest.php
@@ -32,9 +32,9 @@ test('Update command is parsed', function () {
     expect($parsed->command)->toBe(SmsCommandType::Update)
         ->and($parsed->message)->toBe("I'm doing alright");
 
-    $parsed = SmsParser::parse("\n\n\nUPDATE \n : \n I'm\ndoing\nalright \n");
+    $parsed = SmsParser::parse("\n\n\nUPDATE: \n I'm\ndoing\n\nalright \n");
     expect($parsed->command)->toBe(SmsCommandType::Update)
-        ->and($parsed->message)->toBe("I'm\ndoing\nalright");
+        ->and($parsed->message)->toBe("I'm\ndoing\n\nalright");
 })->group('parser');
 
 test('Help command is parsed', function () {


### PR DESCRIPTION
Resolves #16 

- Updates pattern matching to properly strip out stray whitespace and support new lines
- Updates UI to display new lines of text
- Adds tests to check this stuff!

```diff
- preg_match('/^\s*(?P<command>'.$prefixes.')?:?\s*(?P<message>.*)\s*$/i', $body, $matches);
+ preg_match('/^\s*(?P<command>'.$prefixes.')?\s*:?\s*(?P<message>.*?)\s*$/is', $body, $matches);
```
Explanation of pattern changes:
- Addition of `\s*` before `:?` supports any whitespace before keyword, e.g. `UPDATE   \n: 123` _(note: I'm ok if we take this one out)_
- Addition of `?` (lazy operator) to `<message>.*` trims off trailing whitespace that `\s` matches, e.g. `123      \n` becomes `123`
- Addition of `s` flag to `/is` allows `.` to match new lines

![Screenshot 2024-10-02 at 01 01 50@2x](https://github.com/user-attachments/assets/a140bf64-69df-4e83-b793-d711bc51951a)
