### PR TITLE
WIP - Proxy outgoing messages

### DIFF
--- a/app/Http/Controllers/TwilioProxyController.php
+++ b/app/Http/Controllers/TwilioProxyController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Exception;
+use Illuminate\Auth\AuthenticationException;
+use Twilio\Rest\Client;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+
+class TwilioProxyController extends Controller
+{
+    public function __invoke(Request $request)
+    {
+        $validated = (object) $request->validate([
+            'key' => 'required|string',
+            'to' => 'required|string|phone:US',
+            'from' => 'required|string|phone:US',
+            'message' => 'required|string|max:160',
+        ]);
+
+        $this->validateSenderKey($validated->key, $validated->from);
+
+        $twilioClient = new Client(
+            config('services.twilio.sid'),
+            config('services.twilio.token')
+        );
+
+        try {
+            $message = $twilioClient->messages->create(
+                $validated->to,
+                [
+                    'from' => $validated->from,
+                    'body' => $validated->message,
+                ]
+            );
+
+            return response()->json(['success' => true, 'message_sid' => $message->sid]);
+        } catch (\Exception $e) {
+            return response()->json(['error' => $e->getMessage()], 500);
+        }
+    }
+
+    protected function validateSenderKey(string $key, string $from): void
+    {
+        if (
+            ! Hash::check($from, $key)
+        ) {
+            throw new AuthenticationException('Key is invalid for this sending number.');
+        }
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -15,6 +15,7 @@ return [
     */
 
     'twilio' => [
+        'sid' => env('TWILIO_SID', ''),
         'auth_tokens' => explode(',', env('TWILIO_AUTH_TOKENS', env('TWILIO_AUTH_TOKEN', ''))),
     ],
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,9 +1,12 @@
 <?php
 
-use App\Http\Controllers\Webhooks\TwilioWebhookController;
-use App\Http\Middleware\TwilioSignatureMiddleware;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\TwilioProxyController;
+use App\Http\Controllers\Webhooks\TwilioWebhookController;
+
+Route::post('/proxy/twilio', TwilioProxyController::class);
 
 Route::post('/webhooks/twilio', TwilioWebhookController::class)
     // ->middleware(TwilioSignatureMiddleware::class)
     ->name('webhooks.twilio');
+


### PR DESCRIPTION
I am going to need to be able to send messages off the 828 number for the water project in the next day or two.

We can pull the SID and stuff into our app, but now that checkins are really slowing down, I think it may be wise to think about building an app that is simply a proxy which routes incoming commands to the correct apps and proxies outgoing messages.

It can also house the global "unsubscribe" list for the number.

This is a first step toward that.